### PR TITLE
[BOT] Add a script that publishes the built bottles automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,16 @@ jobs:
 
     steps: *build-steps
 
+  update-with-bot-commit:
+    docker:
+      - image: circleci/python
+    steps:
+      - add_ssh_keys
+      - checkout
+      - run:
+          name: Publish bottle information
+          command: bash -c .circleci/publish-bottle-info.sh
+
 workflows:
   version: 2.1
   build-bottles:
@@ -63,3 +73,9 @@ workflows:
       - bottle-catalina:
           requires:
             - includes-bottleable-commits
+      - update-with-bot-commit:
+          requires:
+            - includes-bottleable-commits
+            - bottle-mojave
+            - bottle-high-sierra
+            - bottle-catalina

--- a/.circleci/publish-bottle-info.sh
+++ b/.circleci/publish-bottle-info.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+FILES_BUILT=$(git diff --name-status HEAD~1 HEAD | grep '^[AM]' | grep 'Formula' | cut -f2)
+
+[ -z "$FILES_BUILT" ] && echo "No formulae to bottle right now." && exit 0
+
+echo "Collecting signatures for $FILES_BUILT"
+
+pip install awscli
+
+git config user.email "circleci@fishtownanalytics.com"
+git config user.name "CircleCI Bottling Bot"
+
+while read -r line; do
+    FORMULA_NAME_WITH_RB_EXTENSION="${line/Formula\//}"
+    FORMULA_NAME="${FORMULA_NAME_WITH_RB_EXTENSION/.rb/}"
+
+    [[ -z $FORMULA_NAME ]] && echo "No formula name found???" && exit 1
+
+    echo "------ COLLECTING JSON FILES -------"
+    [[ -e json ]] && rm -r json
+    mkdir -p json
+    JSON_FILES=$(python -m awscli s3 ls 's3://bottles.getdbt.com/' | awk '{print $4}' | grep "^${FORMULA_NAME}.*.json")
+    while read -r json_path; do
+        echo "copying s3://bottles.getdbt.com/${json_path}"
+        python -m awscli s3 cp "s3://bottles.getdbt.com/${json_path}" ./json/
+    done <<< "$JSON_FILES"
+
+    echo "------ WRITING BOTTLE HASHES -------"
+    python ./.circleci/rewrite-formula.py "$line"
+
+    echo "--------- COMMIT CHANGES -----------"
+    git add $line
+    git commit -m "[BOT] dbt ${FORMULA_NAME} bottled"
+    git push
+
+done <<< "$FILES_BUILT"
+
+echo 'added BOT commits for all forumlae'

--- a/.circleci/rewrite-formula.py
+++ b/.circleci/rewrite-formula.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+# this script should work with almost any python version, I think
+
+import argparse
+import glob
+import json
+
+
+def get_replacement_lines():
+    replacements = []
+    for file in glob.glob('./json/*.json'):
+        with open(file) as fp:
+            data = json.load(fp)
+        value = list(data.values())[0]
+        tags = value['bottle']['tags']
+        os_name = list(tags.keys())[0]
+        sha256 = tags[os_name]['sha256']
+        replacements.append(f'    sha256 "{sha256}" => :{os_name}\n')
+    return replacements
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('formula_path')
+    parsed = parser.parse_args()
+    path = parsed.formula_path
+
+    replacements = get_replacement_lines()
+    assert len(replacements) > 0, 'No replacement lines found!'
+
+    to_emit = []
+    replaced = False
+    with open(path) as fp:
+        for line in fp:
+            if line.startswith('    # bottle hashes + versions go here'):
+                to_emit.extend(replacements)
+                replaced = True
+            else:
+                to_emit.append(line)
+    assert replaced, 'Never found the magic line to replace!'
+    with open(path, 'w') as fp:
+        fp.write(''.join(to_emit))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The [BOT] tag is to avoid triggering circleci builds if this merges

I tried to write the json stuff in jq + sed at first, but it was painful. I wrote a python script instead.

Basically, if the bottling code runs, also automatically generate and push a commit that contains the completed bottle hash info.

This relies on the formula being generated by the script in [this PR](https://github.com/fishtown-analytics/dbt/pull/2119) - in particular the "magic string" of `    # bottle hashes + versions go here`.

I generated the most recent master commit with this script (except for the mis-cased `[bot]` commit, oops - fixed it in the script)

I'm not saying this is perfect, but it seems reasonable enough.