### PR TITLE
bump cffi version to 1.14.4 to fix dbt 0.18.1 installation

### DIFF
--- a/Formula/dbt.rb
+++ b/Formula/dbt.rb
@@ -97,9 +97,9 @@ class Dbt < Formula
     sha256 "5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"
   end
 
-  resource "cffi" do # cffi==1.14.3
-    url "https://files.pythonhosted.org/packages/cb/ae/380e33d621ae301770358eb11a896a34c34f30db188847a561e8e39ee866/cffi-1.14.3.tar.gz"
-    sha256 "f92f789e4f9241cd262ad7a555ca2c648a98178a953af117ef7fad46aa1d5591"
+  resource "cffi" do # cffi==1.14.4
+    url "https://files.pythonhosted.org/packages/66/6a/98e023b3d11537a5521902ac6b50db470c826c682be6a8c661549cb7717a/cffi-1.14.4.tar.gz"
+    sha256 "1a465cbe98a7fd391d47dce4b8f7e5b921e6cd805ef421d04f5f66ba8f06086c"
   end
 
   resource "chardet" do # chardet==3.0.4

--- a/Formula/dbt@0.18.1.rb
+++ b/Formula/dbt@0.18.1.rb
@@ -97,9 +97,9 @@ class DbtAT0181 < Formula
     sha256 "5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"
   end
 
-  resource "cffi" do # cffi==1.14.3
-    url "https://files.pythonhosted.org/packages/cb/ae/380e33d621ae301770358eb11a896a34c34f30db188847a561e8e39ee866/cffi-1.14.3.tar.gz"
-    sha256 "f92f789e4f9241cd262ad7a555ca2c648a98178a953af117ef7fad46aa1d5591"
+  resource "cffi" do # cffi==1.14.4
+    url "https://files.pythonhosted.org/packages/66/6a/98e023b3d11537a5521902ac6b50db470c826c682be6a8c661549cb7717a/cffi-1.14.4.tar.gz"
+    sha256 "1a465cbe98a7fd391d47dce4b8f7e5b921e6cd805ef421d04f5f66ba8f06086c"
   end
 
   resource "chardet" do # chardet==3.0.4


### PR DESCRIPTION
### Issue 🐞 

0.18.1 fails to install with the recently released brew managed python3.8. It causes the installation of the `cffi` dependency to fail with the following error.

```console
/usr/local/Cellar/dbt/0.18.1_1/libexec/bin/pip
install
-v
--no-deps
--no-binary
:all:
--ignore-installed
/private/tmp/dbt--cffi-20210103-24913-i18ylh/cffi-1.14.3
Using pip 20.3.1 from /usr/local/Cellar/dbt/0.18.1_1/libexec/lib/python3.8/site-packages/pip (python
 3.8)
Non-user install because user site-packages disabled
Created temporary directory: /private/tmp/pip-ephem-wheel-cache-8___9lmg
Created temporary directory: /private/tmp/pip-req-tracker-u8__4k92
Initialized build tracking at /private/tmp/pip-req-tracker-u8__4k92
Created build tracker: /private/tmp/pip-req-tracker-u8__4k92
Entered build tracker: /private/tmp/pip-req-tracker-u8__4k92
Created temporary directory: /private/tmp/pip-install-t124rgep
Processing /private/tmp/dbt--cffi-20210103-24913-i18ylh/cffi-1.14.3
  Created temporary directory: /private/tmp/pip-req-build-h3sy4f71
  Added file:///private/tmp/dbt--cffi-20210103-24913-i18ylh/cffi-1.14.3 to build tracker '/private/t
mp/pip-req-tracker-u8__4k92'
    Running setup.py (path:/private/tmp/pip-req-build-h3sy4f71/setup.py) egg_info for package from f
ile:///private/tmp/dbt--cffi-20210103-24913-i18ylh/cffi-1.14.3
    Created temporary directory: /private/tmp/pip-pip-egg-info-4medsm4g
    Running command python setup.py egg_info
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/tmp/pip-req-build-h3sy4f71/setup.py", line 152, in <module>
        if 'darwin' in sys.platform and macosx_deployment_target() >= (10, 15):
      File "/private/tmp/pip-req-build-h3sy4f71/setup.py", line 76, in macosx_deployment_target
        return tuple(map(int, get_config_var("MACOSX_DEPLOYMENT_TARGET").split('.')))
    AttributeError: 'int' object has no attribute 'split'
```

Python version:
```console
Python 3.8.7 (default, Dec 30 2020, 10:14:55)
[Clang 12.0.0 (clang-1200.0.32.28)]
```

### Fix 🔧 
`cffi` removed the function call to the code causing this issue in `v1.14.4`. ([source](https://foss.heptapod.net/pypy/cffi/-/compare/v1.14.3...v1.14.4#8e2edce0d507e1297474f25c00cae94258db38d8_152_152)) This PR bumps `cffi` to `1.14.4` for 0.18.1 (and the default Homebrew dbt installation). This is an appropriate fix IMO because it mimics the same behavior as the pip installation which uses `1.14.4` 👍 

pip installation example:
```console
$ pip install dbt
....
$ dbt --version
installed version: 0.18.1
   latest version: 0.18.1

Up to date!

Plugins:
  - bigquery: 0.18.1
  - snowflake: 0.18.1
  - redshift: 0.18.1
  - postgres: 0.18.1
$ pip freeze | grep -i cffi
cffi==1.14.4
```

### Testing ✏️ 

Tested manually on my macbook running Big Sur.
``` console
$ sw_vers -productVersion
11.1
$ xcodebuild -version
Xcode 12.3
Build version 12C33
```

