### PR TITLE
Officially disable homebrew

### DIFF
--- a/.github/formula-template.j2
+++ b/.github/formula-template.j2
@@ -1,4 +1,5 @@
 class {{ classname }} < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "{{ summary|capitalize }}"

--- a/.github/formula-template.j2
+++ b/.github/formula-template.j2
@@ -1,5 +1,5 @@
 class {{ classname }} < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "{{ summary|capitalize }}"

--- a/Formula/dbt-bigquery.rb
+++ b/Formula/dbt-bigquery.rb
@@ -1,4 +1,5 @@
 class DbtBigquery < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery.rb
+++ b/Formula/dbt-bigquery.rb
@@ -1,5 +1,5 @@
 class DbtBigquery < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.0.0-b1.rb
+++ b/Formula/dbt-bigquery@1.0.0-b1.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT100B1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.0.0-b1.rb
+++ b/Formula/dbt-bigquery@1.0.0-b1.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT100B1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.0.0-rc2.rb
+++ b/Formula/dbt-bigquery@1.0.0-rc2.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT100Rc2 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.0.0-rc2.rb
+++ b/Formula/dbt-bigquery@1.0.0-rc2.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT100Rc2 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.0.0.rb
+++ b/Formula/dbt-bigquery@1.0.0.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT100 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.0.0.rb
+++ b/Formula/dbt-bigquery@1.0.0.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT100 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.1.0-rc1.rb
+++ b/Formula/dbt-bigquery@1.1.0-rc1.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT110Rc1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.1.0-rc1.rb
+++ b/Formula/dbt-bigquery@1.1.0-rc1.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT110Rc1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.1.0.rb
+++ b/Formula/dbt-bigquery@1.1.0.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT110 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.1.0.rb
+++ b/Formula/dbt-bigquery@1.1.0.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT110 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.1.1.rb
+++ b/Formula/dbt-bigquery@1.1.1.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT111 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.1.1.rb
+++ b/Formula/dbt-bigquery@1.1.1.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT111 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.2.0-rc1.rb
+++ b/Formula/dbt-bigquery@1.2.0-rc1.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT120Rc1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.2.0-rc1.rb
+++ b/Formula/dbt-bigquery@1.2.0-rc1.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT120Rc1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.2.0.rb
+++ b/Formula/dbt-bigquery@1.2.0.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT120 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.2.0.rb
+++ b/Formula/dbt-bigquery@1.2.0.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT120 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.2.1.rb
+++ b/Formula/dbt-bigquery@1.2.1.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT121 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.2.1.rb
+++ b/Formula/dbt-bigquery@1.2.1.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT121 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.3.0-b1.rb
+++ b/Formula/dbt-bigquery@1.3.0-b1.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT130B1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.3.0-b1.rb
+++ b/Formula/dbt-bigquery@1.3.0-b1.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT130B1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.3.0-rc2.rb
+++ b/Formula/dbt-bigquery@1.3.0-rc2.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT130Rc2 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.3.0-rc2.rb
+++ b/Formula/dbt-bigquery@1.3.0-rc2.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT130Rc2 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.3.0.rb
+++ b/Formula/dbt-bigquery@1.3.0.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT130 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.3.0.rb
+++ b/Formula/dbt-bigquery@1.3.0.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT130 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.3.1.rb
+++ b/Formula/dbt-bigquery@1.3.1.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT131 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.3.1.rb
+++ b/Formula/dbt-bigquery@1.3.1.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT131 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.3.2.rb
+++ b/Formula/dbt-bigquery@1.3.2.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT132 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.3.2.rb
+++ b/Formula/dbt-bigquery@1.3.2.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT132 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.3.3.rb
+++ b/Formula/dbt-bigquery@1.3.3.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT133 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.3.3.rb
+++ b/Formula/dbt-bigquery@1.3.3.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT133 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.4.0.rb
+++ b/Formula/dbt-bigquery@1.4.0.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT140 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.4.0.rb
+++ b/Formula/dbt-bigquery@1.4.0.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT140 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.4.1.rb
+++ b/Formula/dbt-bigquery@1.4.1.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT141 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.4.1.rb
+++ b/Formula/dbt-bigquery@1.4.1.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT141 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.4.2.rb
+++ b/Formula/dbt-bigquery@1.4.2.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT142 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.4.2.rb
+++ b/Formula/dbt-bigquery@1.4.2.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT142 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.4.3.rb
+++ b/Formula/dbt-bigquery@1.4.3.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT143 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.4.3.rb
+++ b/Formula/dbt-bigquery@1.4.3.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT143 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.4.4.rb
+++ b/Formula/dbt-bigquery@1.4.4.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT144 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.4.4.rb
+++ b/Formula/dbt-bigquery@1.4.4.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT144 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.4.5.rb
+++ b/Formula/dbt-bigquery@1.4.5.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT145 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.4.5.rb
+++ b/Formula/dbt-bigquery@1.4.5.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT145 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.0-rc1.rb
+++ b/Formula/dbt-bigquery@1.5.0-rc1.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT150Rc1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.0-rc1.rb
+++ b/Formula/dbt-bigquery@1.5.0-rc1.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT150Rc1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.0.rb
+++ b/Formula/dbt-bigquery@1.5.0.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT150 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.0.rb
+++ b/Formula/dbt-bigquery@1.5.0.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT150 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.1.rb
+++ b/Formula/dbt-bigquery@1.5.1.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT151 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.1.rb
+++ b/Formula/dbt-bigquery@1.5.1.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT151 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.2.rb
+++ b/Formula/dbt-bigquery@1.5.2.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT152 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.2.rb
+++ b/Formula/dbt-bigquery@1.5.2.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT152 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.3.rb
+++ b/Formula/dbt-bigquery@1.5.3.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT153 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.3.rb
+++ b/Formula/dbt-bigquery@1.5.3.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT153 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.4.rb
+++ b/Formula/dbt-bigquery@1.5.4.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT154 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.4.rb
+++ b/Formula/dbt-bigquery@1.5.4.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT154 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.5.rb
+++ b/Formula/dbt-bigquery@1.5.5.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT155 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.5.rb
+++ b/Formula/dbt-bigquery@1.5.5.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT155 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.6.rb
+++ b/Formula/dbt-bigquery@1.5.6.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT156 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.6.rb
+++ b/Formula/dbt-bigquery@1.5.6.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT156 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.7.rb
+++ b/Formula/dbt-bigquery@1.5.7.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT157 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.7.rb
+++ b/Formula/dbt-bigquery@1.5.7.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT157 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.8.rb
+++ b/Formula/dbt-bigquery@1.5.8.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT158 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.8.rb
+++ b/Formula/dbt-bigquery@1.5.8.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT158 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.9.rb
+++ b/Formula/dbt-bigquery@1.5.9.rb
@@ -1,5 +1,5 @@
 class DbtBigqueryAT159 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-bigquery@1.5.9.rb
+++ b/Formula/dbt-bigquery@1.5.9.rb
@@ -1,4 +1,5 @@
 class DbtBigqueryAT159 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Bigquery adapter plugin for dbt"

--- a/Formula/dbt-development.rb
+++ b/Formula/dbt-development.rb
@@ -1,5 +1,5 @@
 class DbtDevelopment < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Data build tool"

--- a/Formula/dbt-development.rb
+++ b/Formula/dbt-development.rb
@@ -1,4 +1,5 @@
 class DbtDevelopment < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Data build tool"

--- a/Formula/dbt-postgres.rb
+++ b/Formula/dbt-postgres.rb
@@ -1,4 +1,5 @@
 class DbtPostgres < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres.rb
+++ b/Formula/dbt-postgres.rb
@@ -1,5 +1,5 @@
 class DbtPostgres < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.0.3.rb
+++ b/Formula/dbt-postgres@1.0.3.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT103 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.0.3.rb
+++ b/Formula/dbt-postgres@1.0.3.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT103 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.0.4.rb
+++ b/Formula/dbt-postgres@1.0.4.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT104 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.0.4.rb
+++ b/Formula/dbt-postgres@1.0.4.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT104 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.0.5.rb
+++ b/Formula/dbt-postgres@1.0.5.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT105 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.0.5.rb
+++ b/Formula/dbt-postgres@1.0.5.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT105 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.0.6.rb
+++ b/Formula/dbt-postgres@1.0.6.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT106 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.0.6.rb
+++ b/Formula/dbt-postgres@1.0.6.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT106 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.0.7.rb
+++ b/Formula/dbt-postgres@1.0.7.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT107 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.0.7.rb
+++ b/Formula/dbt-postgres@1.0.7.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT107 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.1.0-rc1.rb
+++ b/Formula/dbt-postgres@1.1.0-rc1.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT110Rc1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.1.0-rc1.rb
+++ b/Formula/dbt-postgres@1.1.0-rc1.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT110Rc1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.1.0.rb
+++ b/Formula/dbt-postgres@1.1.0.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT110 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.1.0.rb
+++ b/Formula/dbt-postgres@1.1.0.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT110 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.1.1.rb
+++ b/Formula/dbt-postgres@1.1.1.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT111 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.1.1.rb
+++ b/Formula/dbt-postgres@1.1.1.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT111 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.1.2.rb
+++ b/Formula/dbt-postgres@1.1.2.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT112 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.1.2.rb
+++ b/Formula/dbt-postgres@1.1.2.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT112 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.2.0-rc2.rb
+++ b/Formula/dbt-postgres@1.2.0-rc2.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT120Rc2 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.2.0-rc2.rb
+++ b/Formula/dbt-postgres@1.2.0-rc2.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT120Rc2 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.2.0.rb
+++ b/Formula/dbt-postgres@1.2.0.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT120 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.2.0.rb
+++ b/Formula/dbt-postgres@1.2.0.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT120 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.2.1.rb
+++ b/Formula/dbt-postgres@1.2.1.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT121 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.2.1.rb
+++ b/Formula/dbt-postgres@1.2.1.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT121 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.2.2.rb
+++ b/Formula/dbt-postgres@1.2.2.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT122 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.2.2.rb
+++ b/Formula/dbt-postgres@1.2.2.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT122 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.2.3.rb
+++ b/Formula/dbt-postgres@1.2.3.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT123 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.2.3.rb
+++ b/Formula/dbt-postgres@1.2.3.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT123 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.2.5.rb
+++ b/Formula/dbt-postgres@1.2.5.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT125 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.2.5.rb
+++ b/Formula/dbt-postgres@1.2.5.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT125 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.3.0-b1.rb
+++ b/Formula/dbt-postgres@1.3.0-b1.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT130B1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.3.0-b1.rb
+++ b/Formula/dbt-postgres@1.3.0-b1.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT130B1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.3.0-rc2.rb
+++ b/Formula/dbt-postgres@1.3.0-rc2.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT130Rc2 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.3.0-rc2.rb
+++ b/Formula/dbt-postgres@1.3.0-rc2.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT130Rc2 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.3.0.rb
+++ b/Formula/dbt-postgres@1.3.0.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT130 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.3.0.rb
+++ b/Formula/dbt-postgres@1.3.0.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT130 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.3.1.rb
+++ b/Formula/dbt-postgres@1.3.1.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT131 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.3.1.rb
+++ b/Formula/dbt-postgres@1.3.1.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT131 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.3.2.rb
+++ b/Formula/dbt-postgres@1.3.2.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT132 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.3.2.rb
+++ b/Formula/dbt-postgres@1.3.2.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT132 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.3.3.rb
+++ b/Formula/dbt-postgres@1.3.3.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT133 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.3.3.rb
+++ b/Formula/dbt-postgres@1.3.3.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT133 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.3.4.rb
+++ b/Formula/dbt-postgres@1.3.4.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT134 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.3.4.rb
+++ b/Formula/dbt-postgres@1.3.4.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT134 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.3.5.rb
+++ b/Formula/dbt-postgres@1.3.5.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT135 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.3.5.rb
+++ b/Formula/dbt-postgres@1.3.5.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT135 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.4.0.rb
+++ b/Formula/dbt-postgres@1.4.0.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT140 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.4.0.rb
+++ b/Formula/dbt-postgres@1.4.0.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT140 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.4.1.rb
+++ b/Formula/dbt-postgres@1.4.1.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT141 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.4.1.rb
+++ b/Formula/dbt-postgres@1.4.1.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT141 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.4.2.rb
+++ b/Formula/dbt-postgres@1.4.2.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT142 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.4.2.rb
+++ b/Formula/dbt-postgres@1.4.2.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT142 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.4.3.rb
+++ b/Formula/dbt-postgres@1.4.3.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT143 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.4.3.rb
+++ b/Formula/dbt-postgres@1.4.3.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT143 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.4.4.rb
+++ b/Formula/dbt-postgres@1.4.4.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT144 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.4.4.rb
+++ b/Formula/dbt-postgres@1.4.4.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT144 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.4.5.rb
+++ b/Formula/dbt-postgres@1.4.5.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT145 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.4.5.rb
+++ b/Formula/dbt-postgres@1.4.5.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT145 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.4.6.rb
+++ b/Formula/dbt-postgres@1.4.6.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT146 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.4.6.rb
+++ b/Formula/dbt-postgres@1.4.6.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT146 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.4.7.rb
+++ b/Formula/dbt-postgres@1.4.7.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT147 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.4.7.rb
+++ b/Formula/dbt-postgres@1.4.7.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT147 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.0-rc1.rb
+++ b/Formula/dbt-postgres@1.5.0-rc1.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT150Rc1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.0-rc1.rb
+++ b/Formula/dbt-postgres@1.5.0-rc1.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT150Rc1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.0.rb
+++ b/Formula/dbt-postgres@1.5.0.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT150 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.0.rb
+++ b/Formula/dbt-postgres@1.5.0.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT150 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.1.rb
+++ b/Formula/dbt-postgres@1.5.1.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT151 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.1.rb
+++ b/Formula/dbt-postgres@1.5.1.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT151 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.10.rb
+++ b/Formula/dbt-postgres@1.5.10.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT1510 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.10.rb
+++ b/Formula/dbt-postgres@1.5.10.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT1510 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.2.rb
+++ b/Formula/dbt-postgres@1.5.2.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT152 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.2.rb
+++ b/Formula/dbt-postgres@1.5.2.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT152 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.3.rb
+++ b/Formula/dbt-postgres@1.5.3.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT153 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.3.rb
+++ b/Formula/dbt-postgres@1.5.3.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT153 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.4.rb
+++ b/Formula/dbt-postgres@1.5.4.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT154 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.4.rb
+++ b/Formula/dbt-postgres@1.5.4.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT154 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.5.rb
+++ b/Formula/dbt-postgres@1.5.5.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT155 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.5.rb
+++ b/Formula/dbt-postgres@1.5.5.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT155 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.6.rb
+++ b/Formula/dbt-postgres@1.5.6.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT156 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.6.rb
+++ b/Formula/dbt-postgres@1.5.6.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT156 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.7.rb
+++ b/Formula/dbt-postgres@1.5.7.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT157 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.7.rb
+++ b/Formula/dbt-postgres@1.5.7.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT157 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.8.rb
+++ b/Formula/dbt-postgres@1.5.8.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT158 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.8.rb
+++ b/Formula/dbt-postgres@1.5.8.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT158 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.9.rb
+++ b/Formula/dbt-postgres@1.5.9.rb
@@ -1,4 +1,5 @@
 class DbtPostgresAT159 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-postgres@1.5.9.rb
+++ b/Formula/dbt-postgres@1.5.9.rb
@@ -1,5 +1,5 @@
 class DbtPostgresAT159 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Postgres adapter plugin for dbt (data build tool)"

--- a/Formula/dbt-redshift.rb
+++ b/Formula/dbt-redshift.rb
@@ -1,5 +1,5 @@
 class DbtRedshift < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift.rb
+++ b/Formula/dbt-redshift.rb
@@ -1,4 +1,5 @@
 class DbtRedshift < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.0.0-b1.rb
+++ b/Formula/dbt-redshift@1.0.0-b1.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT100B1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.0.0-b1.rb
+++ b/Formula/dbt-redshift@1.0.0-b1.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT100B1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.0.0-rc2.rb
+++ b/Formula/dbt-redshift@1.0.0-rc2.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT100Rc2 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.0.0-rc2.rb
+++ b/Formula/dbt-redshift@1.0.0-rc2.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT100Rc2 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.0.0.rb
+++ b/Formula/dbt-redshift@1.0.0.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT100 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.0.0.rb
+++ b/Formula/dbt-redshift@1.0.0.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT100 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.0.1.rb
+++ b/Formula/dbt-redshift@1.0.1.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT101 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.0.1.rb
+++ b/Formula/dbt-redshift@1.0.1.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT101 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.1.0-rc1.rb
+++ b/Formula/dbt-redshift@1.1.0-rc1.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT110Rc1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.1.0-rc1.rb
+++ b/Formula/dbt-redshift@1.1.0-rc1.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT110Rc1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.1.0.rb
+++ b/Formula/dbt-redshift@1.1.0.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT110 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.1.0.rb
+++ b/Formula/dbt-redshift@1.1.0.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT110 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.2.0-rc1.rb
+++ b/Formula/dbt-redshift@1.2.0-rc1.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT120Rc1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.2.0-rc1.rb
+++ b/Formula/dbt-redshift@1.2.0-rc1.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT120Rc1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.2.0.rb
+++ b/Formula/dbt-redshift@1.2.0.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT120 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.2.0.rb
+++ b/Formula/dbt-redshift@1.2.0.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT120 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.2.1.rb
+++ b/Formula/dbt-redshift@1.2.1.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT121 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.2.1.rb
+++ b/Formula/dbt-redshift@1.2.1.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT121 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.3.0-b1.rb
+++ b/Formula/dbt-redshift@1.3.0-b1.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT130B1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.3.0-b1.rb
+++ b/Formula/dbt-redshift@1.3.0-b1.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT130B1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.3.0-rc2.rb
+++ b/Formula/dbt-redshift@1.3.0-rc2.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT130Rc2 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.3.0-rc2.rb
+++ b/Formula/dbt-redshift@1.3.0-rc2.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT130Rc2 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.3.0.rb
+++ b/Formula/dbt-redshift@1.3.0.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT130 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.3.0.rb
+++ b/Formula/dbt-redshift@1.3.0.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT130 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.3.1.rb
+++ b/Formula/dbt-redshift@1.3.1.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT131 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.3.1.rb
+++ b/Formula/dbt-redshift@1.3.1.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT131 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.4.0.rb
+++ b/Formula/dbt-redshift@1.4.0.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT140 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.4.0.rb
+++ b/Formula/dbt-redshift@1.4.0.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT140 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.4.1.rb
+++ b/Formula/dbt-redshift@1.4.1.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT141 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.4.1.rb
+++ b/Formula/dbt-redshift@1.4.1.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT141 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.0.rb
+++ b/Formula/dbt-redshift@1.5.0.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT150 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.0.rb
+++ b/Formula/dbt-redshift@1.5.0.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT150 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.1.rb
+++ b/Formula/dbt-redshift@1.5.1.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT151 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.1.rb
+++ b/Formula/dbt-redshift@1.5.1.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT151 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.10.rb
+++ b/Formula/dbt-redshift@1.5.10.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT1510 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.10.rb
+++ b/Formula/dbt-redshift@1.5.10.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT1510 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.11.rb
+++ b/Formula/dbt-redshift@1.5.11.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT1511 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.11.rb
+++ b/Formula/dbt-redshift@1.5.11.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT1511 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.12.rb
+++ b/Formula/dbt-redshift@1.5.12.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT1512 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.12.rb
+++ b/Formula/dbt-redshift@1.5.12.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT1512 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.2.rb
+++ b/Formula/dbt-redshift@1.5.2.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT152 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.2.rb
+++ b/Formula/dbt-redshift@1.5.2.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT152 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.3.rb
+++ b/Formula/dbt-redshift@1.5.3.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT153 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.3.rb
+++ b/Formula/dbt-redshift@1.5.3.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT153 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.4.rb
+++ b/Formula/dbt-redshift@1.5.4.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT154 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.4.rb
+++ b/Formula/dbt-redshift@1.5.4.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT154 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.5.rb
+++ b/Formula/dbt-redshift@1.5.5.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT155 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.5.rb
+++ b/Formula/dbt-redshift@1.5.5.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT155 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.6.rb
+++ b/Formula/dbt-redshift@1.5.6.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT156 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.6.rb
+++ b/Formula/dbt-redshift@1.5.6.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT156 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.7.rb
+++ b/Formula/dbt-redshift@1.5.7.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT157 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.7.rb
+++ b/Formula/dbt-redshift@1.5.7.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT157 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.8.rb
+++ b/Formula/dbt-redshift@1.5.8.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT158 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.8.rb
+++ b/Formula/dbt-redshift@1.5.8.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT158 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.9.rb
+++ b/Formula/dbt-redshift@1.5.9.rb
@@ -1,5 +1,5 @@
 class DbtRedshiftAT159 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-redshift@1.5.9.rb
+++ b/Formula/dbt-redshift@1.5.9.rb
@@ -1,4 +1,5 @@
 class DbtRedshiftAT159 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Redshift adapter plugin for dbt"

--- a/Formula/dbt-snowflake.rb
+++ b/Formula/dbt-snowflake.rb
@@ -1,5 +1,5 @@
 class DbtSnowflake < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake.rb
+++ b/Formula/dbt-snowflake.rb
@@ -1,4 +1,5 @@
 class DbtSnowflake < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.0.0-b1.rb
+++ b/Formula/dbt-snowflake@1.0.0-b1.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT100B1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "dbt-snowflake contains all of the code enabling dbt to work with Snowflake"

--- a/Formula/dbt-snowflake@1.0.0-b1.rb
+++ b/Formula/dbt-snowflake@1.0.0-b1.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT100B1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "dbt-snowflake contains all of the code enabling dbt to work with Snowflake"

--- a/Formula/dbt-snowflake@1.0.0-rc2.rb
+++ b/Formula/dbt-snowflake@1.0.0-rc2.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT100Rc2 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.0.0-rc2.rb
+++ b/Formula/dbt-snowflake@1.0.0-rc2.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT100Rc2 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.0.0.rb
+++ b/Formula/dbt-snowflake@1.0.0.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT100 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.0.0.rb
+++ b/Formula/dbt-snowflake@1.0.0.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT100 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.0.1.rb
+++ b/Formula/dbt-snowflake@1.0.1.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT101 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.0.1.rb
+++ b/Formula/dbt-snowflake@1.0.1.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT101 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.1.0-rc1.rb
+++ b/Formula/dbt-snowflake@1.1.0-rc1.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT110Rc1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.1.0-rc1.rb
+++ b/Formula/dbt-snowflake@1.1.0-rc1.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT110Rc1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.1.0.rb
+++ b/Formula/dbt-snowflake@1.1.0.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT110 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.1.0.rb
+++ b/Formula/dbt-snowflake@1.1.0.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT110 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.2.0-rc1.rb
+++ b/Formula/dbt-snowflake@1.2.0-rc1.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT120Rc1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.2.0-rc1.rb
+++ b/Formula/dbt-snowflake@1.2.0-rc1.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT120Rc1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.2.0.rb
+++ b/Formula/dbt-snowflake@1.2.0.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT120 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.2.0.rb
+++ b/Formula/dbt-snowflake@1.2.0.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT120 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.2.1.rb
+++ b/Formula/dbt-snowflake@1.2.1.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT121 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.2.1.rb
+++ b/Formula/dbt-snowflake@1.2.1.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT121 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.3.0-b1.rb
+++ b/Formula/dbt-snowflake@1.3.0-b1.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT130B1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.3.0-b1.rb
+++ b/Formula/dbt-snowflake@1.3.0-b1.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT130B1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.3.0-rc2.rb
+++ b/Formula/dbt-snowflake@1.3.0-rc2.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT130Rc2 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.3.0-rc2.rb
+++ b/Formula/dbt-snowflake@1.3.0-rc2.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT130Rc2 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.3.0.rb
+++ b/Formula/dbt-snowflake@1.3.0.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT130 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.3.0.rb
+++ b/Formula/dbt-snowflake@1.3.0.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT130 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.3.1.rb
+++ b/Formula/dbt-snowflake@1.3.1.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT131 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.3.1.rb
+++ b/Formula/dbt-snowflake@1.3.1.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT131 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.3.2.rb
+++ b/Formula/dbt-snowflake@1.3.2.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT132 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.3.2.rb
+++ b/Formula/dbt-snowflake@1.3.2.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT132 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.3.3.rb
+++ b/Formula/dbt-snowflake@1.3.3.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT133 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.3.3.rb
+++ b/Formula/dbt-snowflake@1.3.3.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT133 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.4.0.rb
+++ b/Formula/dbt-snowflake@1.4.0.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT140 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.4.0.rb
+++ b/Formula/dbt-snowflake@1.4.0.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT140 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.4.1.rb
+++ b/Formula/dbt-snowflake@1.4.1.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT141 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.4.1.rb
+++ b/Formula/dbt-snowflake@1.4.1.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT141 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.4.2.rb
+++ b/Formula/dbt-snowflake@1.4.2.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT142 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.4.2.rb
+++ b/Formula/dbt-snowflake@1.4.2.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT142 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.4.3.rb
+++ b/Formula/dbt-snowflake@1.4.3.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT143 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.4.3.rb
+++ b/Formula/dbt-snowflake@1.4.3.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT143 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.4.4.rb
+++ b/Formula/dbt-snowflake@1.4.4.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT144 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.4.4.rb
+++ b/Formula/dbt-snowflake@1.4.4.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT144 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.0-rc1.rb
+++ b/Formula/dbt-snowflake@1.5.0-rc1.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT150Rc1 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.0-rc1.rb
+++ b/Formula/dbt-snowflake@1.5.0-rc1.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT150Rc1 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.0.rb
+++ b/Formula/dbt-snowflake@1.5.0.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT150 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.0.rb
+++ b/Formula/dbt-snowflake@1.5.0.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT150 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.1.rb
+++ b/Formula/dbt-snowflake@1.5.1.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT151 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.1.rb
+++ b/Formula/dbt-snowflake@1.5.1.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT151 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.2.rb
+++ b/Formula/dbt-snowflake@1.5.2.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT152 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.2.rb
+++ b/Formula/dbt-snowflake@1.5.2.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT152 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.3.rb
+++ b/Formula/dbt-snowflake@1.5.3.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT153 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.3.rb
+++ b/Formula/dbt-snowflake@1.5.3.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT153 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.4.rb
+++ b/Formula/dbt-snowflake@1.5.4.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT154 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.4.rb
+++ b/Formula/dbt-snowflake@1.5.4.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT154 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.5.rb
+++ b/Formula/dbt-snowflake@1.5.5.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT155 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.5.rb
+++ b/Formula/dbt-snowflake@1.5.5.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT155 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.6.rb
+++ b/Formula/dbt-snowflake@1.5.6.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT156 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.6.rb
+++ b/Formula/dbt-snowflake@1.5.6.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT156 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.7.rb
+++ b/Formula/dbt-snowflake@1.5.7.rb
@@ -1,4 +1,5 @@
 class DbtSnowflakeAT157 < Formula
+  disable! date: "2024-04-27", because: :repo_archived
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/Formula/dbt-snowflake@1.5.7.rb
+++ b/Formula/dbt-snowflake@1.5.7.rb
@@ -1,5 +1,5 @@
 class DbtSnowflakeAT157 < Formula
-  disable! date: "2024-04-27", because: :repo_archived
+  disable! date: "2024-04-27", because: "is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options"
   include Language::Python::Virtualenv
 
   desc "Snowflake adapter plugin for dbt"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+__This repository is now archived__
+
+See our [docs on core installation](https://docs.getdbt.com/docs/core/installation-overview) for alternative supported installation methods.
+
+---
+
 # homebrew-dbt
 
 This repository contains formulae for multiple versions of dbt and supported adapters.


### PR DESCRIPTION
resolves [#9699](https://github.com/dbt-labs/dbt-core/issues/9699)

### Description

- Mark all formulae as disabled.  Disable options [here](https://github.com/Homebrew/brew/blob/b5b37d8c8054bdac8c8c4f00bd01197611172d88/Library/Homebrew/deprecate_disable.rb#L8).  When someone tries to `brew install ...` they will get 
```
Error: dbt-snowflake has been disabled because it is no longer a supported installation method.  See https://docs.getdbt.com/docs/core/installation-overview#install-dbt-core for other options!
```
- Update README
- Once merged this repo will be archived

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
