### PR TITLE
Add dbt-core formula

### DIFF
--- a/Formula/dbt-core.rb
+++ b/Formula/dbt-core.rb
@@ -1,0 +1,37 @@
+class DbtCore < Formula
+  desc "Build analytics the way engineers build applications"
+  homepage "https://getdbt.com"
+  license "Apache-2.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/dbt-labs/dbt-core/releases/download/v2.0.0-alpha.1/dbt-core-2.0.0-alpha.1-aarch64-apple-darwin.tar.gz"
+      sha256 "10d52871b023bb4acfe08a94cd9ad66539093a2eb8157fc7c1e9ebb933f218a8"
+    end
+    on_intel do
+      url "https://github.com/dbt-labs/dbt-core/releases/download/v2.0.0-alpha.1/dbt-core-2.0.0-alpha.1-x86_64-apple-darwin.tar.gz"
+      sha256 "543463f9078f3b6125a2bab5fda8ff678114e7ccd7de1cfb0526c9fdb487d05d"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/dbt-labs/dbt-core/releases/download/v2.0.0-alpha.1/dbt-core-2.0.0-alpha.1-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "83a3cabe2ec2588390fe64f94142b0a0eb8ebf48c90db05cdab1da5d7232789a"
+    end
+    on_intel do
+      url "https://github.com/dbt-labs/dbt-core/releases/download/v2.0.0-alpha.1/dbt-core-2.0.0-alpha.1-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "8342e0027a0df9175c24255282f7db1504582d2efb4fd5472215a2a34857032e"
+    end
+  end
+
+  conflicts_with "dbt", because: "both formulas install the `dbt` binary"
+
+  def install
+    bin.install "dbt-sa-cli" => "dbt"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/dbt --version")
+  end
+end

--- a/Formula/dbt-core.rb
+++ b/Formula/dbt-core.rb
@@ -1,6 +1,7 @@
 class DbtCore < Formula
   desc "Build analytics the way engineers build applications"
   homepage "https://getdbt.com"
+  version "2.0.0-alpha.1"
   license "Apache-2.0"
 
   on_macos do

--- a/Formula/dbt.rb
+++ b/Formula/dbt.rb
@@ -1,5 +1,5 @@
 class Dbt < Formula
-  desc "Fast and enriched dbt compiler and runner"
+  desc "Build analytics the way engineers build applications"
   homepage "https://getdbt.com"
   version "2.0.0-preview.181"
   license :cannot_represent
@@ -26,7 +26,7 @@ class Dbt < Formula
     end
   end
 
-  # conflicts_with "dbt-core", because: "both formulas install the `dbt` binary"
+  conflicts_with "dbt-core", because: "both formulas install the `dbt` binary"
 
   def install
     bin.install "dbt"


### PR DESCRIPTION
## Summary
- Adds a Homebrew formula for **dbt-core v2.0.0-alpha.1**, sourced from the [dbt-core GitHub release](https://github.com/dbt-labs/dbt-core/releases/tag/v2.0.0-alpha.1) assets (macOS & Linux, arm64 & x86_64).
- The release tarball ships a single `dbt-sa-cli` binary, which is installed as `dbt`.
- Mirrors the structure of the existing `dbt` (Fusion) formula field-for-field, including an explicit `version` line. The only intentional differences are the `license` (`Apache-2.0`, since dbt-core is open source), the URLs/SHAs, the reciprocal `conflicts_with`, and the `dbt-sa-cli => dbt` rename.
- Enables the reciprocal `conflicts_with "dbt-core"` in the existing `dbt` (Fusion) formula, since both install the `dbt` binary. The `dbt` formula `desc` was also updated to match.

## Validation
Validated locally before opening this PR:

**macOS (arm64, throwaway tap):**
- `brew style` — no offenses
- `brew install --build-from-source` — succeeds
- `brew test` (`dbt --version`) — passes; reports `dbt-core 2.0.0-alpha.1`
- arm64 macOS SHA256 verified against the published release asset

**Linux (arm64, `homebrew/brew` container):**
- Tapped `dbt-labs/dbt`, checked out this branch, `brew install dbt-core` — succeeds
- `dbt --version` → `dbt-core 2.0.0-alpha.1`
- `dbt --help` lists the expected subcommands (init, run, build, test, …)

## Notes
- Windows `.zip` asset is intentionally omitted (Homebrew does not target Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)