### PR TITLE
Update dbt-core formula to 2.0.0-alpha.3

### DIFF
--- a/Formula/dbt-core.rb
+++ b/Formula/dbt-core.rb
@@ -1,28 +1,28 @@
 class DbtCore < Formula
   desc "Build analytics the way engineers build applications"
   homepage "https://getdbt.com"
-  version "2.0.0-alpha.1"
+  version "2.0.0-alpha.3"
   license "Apache-2.0"
 
   on_macos do
     on_arm do
-      url "https://github.com/dbt-labs/dbt-core/releases/download/v2.0.0-alpha.1/dbt-core-2.0.0-alpha.1-aarch64-apple-darwin.tar.gz"
-      sha256 "10d52871b023bb4acfe08a94cd9ad66539093a2eb8157fc7c1e9ebb933f218a8"
+      url "https://github.com/dbt-labs/dbt-core/releases/download/v2.0.0-alpha.3/dbt-core-2.0.0-alpha.3-aarch64-apple-darwin.tar.gz"
+      sha256 "10d157299fc2bcce38c1c6b1ba208cc1d79edf0700ab467b56f0c59f2909676d"
     end
     on_intel do
-      url "https://github.com/dbt-labs/dbt-core/releases/download/v2.0.0-alpha.1/dbt-core-2.0.0-alpha.1-x86_64-apple-darwin.tar.gz"
-      sha256 "543463f9078f3b6125a2bab5fda8ff678114e7ccd7de1cfb0526c9fdb487d05d"
+      url "https://github.com/dbt-labs/dbt-core/releases/download/v2.0.0-alpha.3/dbt-core-2.0.0-alpha.3-x86_64-apple-darwin.tar.gz"
+      sha256 "2ec1dcffbe9e7ea5577ad18610cca64d6407e1ad436cb450b5fa97adb6c8be1a"
     end
   end
 
   on_linux do
     on_arm do
-      url "https://github.com/dbt-labs/dbt-core/releases/download/v2.0.0-alpha.1/dbt-core-2.0.0-alpha.1-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "83a3cabe2ec2588390fe64f94142b0a0eb8ebf48c90db05cdab1da5d7232789a"
+      url "https://github.com/dbt-labs/dbt-core/releases/download/v2.0.0-alpha.3/dbt-core-2.0.0-alpha.3-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "864c387ca7d1f4350cef43e3092a61c8938b7f273709d3e4777dee595ed4204f"
     end
     on_intel do
-      url "https://github.com/dbt-labs/dbt-core/releases/download/v2.0.0-alpha.1/dbt-core-2.0.0-alpha.1-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "8342e0027a0df9175c24255282f7db1504582d2efb4fd5472215a2a34857032e"
+      url "https://github.com/dbt-labs/dbt-core/releases/download/v2.0.0-alpha.3/dbt-core-2.0.0-alpha.3-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "b5145ae03eb8f686d8a0fbee4895206c5fb3c600b698d276642a14c691fa2ba6"
     end
   end
 


### PR DESCRIPTION
Bumps the `dbt-core` formula from `2.0.0-alpha.1` to `2.0.0-alpha.3` ([release](https://github.com/dbt-labs/dbt-core/releases/tag/v2.0.0-alpha.3)).

Updates the version, all four download URLs, and the SHA256 checksums for macOS (arm64/x86_64) and Linux (arm64/x86_64). Checksums taken from the release `SHA256SUMS`.

## Verification
- Verified downloaded macOS arm64 asset checksum matches the formula.
- Ran the extracted binary: reports `dbt-core 2.0.0-alpha.3`.
- `brew style` passed.
- Installed via a local tap and `brew test` passed (`dbt --version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)